### PR TITLE
Add C function to read token file

### DIFF
--- a/include/fdp/fdp.h
+++ b/include/fdp/fdp.h
@@ -118,7 +118,8 @@ FdpError fdp_link_read(FdpDataPipeline *data_pipeline, const char *data_product,
  * @return Error code
  */
 FdpError fdp_link_write(FdpDataPipeline *data_pipeline,
-                        const char *data_product, char *data_store_path, size_t data_store_path_len);
+                        const char *data_product, char *data_store_path,
+                        size_t data_store_path_len);
 
 /**
  * @brief Enumeration used to denote the different levels of logging.
@@ -167,6 +168,21 @@ FdpLogLevel fdp_get_log_level();
  * @return Error code. 1 if logging unsuccessful, 0 otherwise.
  */
 int fdp_log(FdpLogLevel log_level, const char *msg);
+
+/**
+ * @brief Read token from file.
+ *
+ * @param path The path to the token file.
+ *
+ * @param token Destination to store the token. The user must allocate
+ * sufficient space for the token.
+ *
+ * @param token_len Length of the character array used to store the token.
+ *
+ * @return Error code. Returns 0 if the token was read successfully, or a
+ * positive integer otherwise.
+ */
+FdpError fdp_read_token(const char *path, char *token, size_t token_len);
 
 #ifdef __cplusplus
 

--- a/test/test_c_api.cxx
+++ b/test/test_c_api.cxx
@@ -37,10 +37,12 @@ TEST(CTest, link_read_write) {
   FdpDataPipeline *pipeline;
   fs::path config = fs::path(TESTDIR) / "data" / "write_csv.yaml";
   fs::path script = fs::path(TESTDIR) / "test_script.sh";
-  std::string token =
-      fdp::read_token(fs::path(home_dir()) / ".fair" / "registry" / "token");
+  fs::path token_path = fs::path(home_dir()) / ".fair" / "registry" / "token";
+  char token[BUFFER_SIZE];
+  ASSERT_EQ(fdp_read_token(token_path.c_str(), token, BUFFER_SIZE),
+            FDP_ERR_NONE);
   ASSERT_EQ(fdp_init(&pipeline, config.string().c_str(),
-                     script.string().c_str(), token.c_str()),
+                     script.string().c_str(), token),
             FDP_ERR_NONE);
 
   // Test link write
@@ -58,7 +60,7 @@ TEST(CTest, link_read_write) {
   ASSERT_EQ(fdp_finalise(&pipeline), FDP_ERR_NONE);
   config = fs::path(TESTDIR) / "data" / "read_csv.yaml";
   ASSERT_EQ(fdp_init(&pipeline, config.string().c_str(),
-                     script.string().c_str(), token.c_str()),
+                     script.string().c_str(), token),
             FDP_ERR_NONE);
 
   // Test link read
@@ -111,10 +113,12 @@ TEST(CTest, c_to_cpp) {
   FdpDataPipeline *c_pipeline;
   fs::path config = fs::path(TESTDIR) / "data" / "write_csv.yaml";
   fs::path script = fs::path(TESTDIR) / "test_script.sh";
-  std::string token =
-      fdp::read_token(fs::path(home_dir()) / ".fair" / "registry" / "token");
+  fs::path token_path = fs::path(home_dir()) / ".fair" / "registry" / "token";
+  char token[BUFFER_SIZE];
+  ASSERT_EQ(fdp_read_token(token_path.c_str(), token, BUFFER_SIZE),
+            FDP_ERR_NONE);
   ASSERT_EQ(fdp_init(&c_pipeline, config.string().c_str(),
-                     script.string().c_str(), token.c_str()),
+                     script.string().c_str(), token),
             FDP_ERR_NONE);
 
   // Switch to C++ API


### PR DESCRIPTION
Adds the function `fdp_read_token` that gets the registry token from a file. It's a simple utility, but I had to implement it from scratch in the Fortran API, and exposing it in the C API means that any future changes to the C++/C methods will be automatically carried forward to Fortran or anything else that hooks into the C API.

Also applies clang-format to some older code -- not sure how this was missed the first time around.